### PR TITLE
optimize debug builds a lil

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,11 @@ quad-storage = "0.1.3"
 serde = { version = "1.0.207", features=["serde_derive"] }
 toml = "0.8.19"
 
+# Enable a small amount of optimization in debug mode
+[profile.dev]
+opt-level = 1
+
+# Enable high optimizations for dependencies, but not for our code:
 [profile.dev.package.'*']
 opt-level = 3
 


### PR DESCRIPTION
should lead to a little bit faster compile times when making local
changes; this seems to be true based on a `time` check with `cargo clean
&& cargo build`
