### PR TITLE
save level completion data

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -45,6 +45,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c4b4d0bd25bd0b74681c0ad21497610ce1b7c91b1022cd21c80c6fbdd9476b0"
 
 [[package]]
+name = "base64"
+version = "0.21.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -55,6 +61,9 @@ name = "bitflags"
 version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b048fb63fd8b5923fc5aa7b340d8e156aec7ec02f0c78fa8a6ddc2613f6f71de"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "bumpalo"
@@ -629,6 +638,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "ron"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b91f7eff05f748767f183df4320a63d6936e9c6107d97c9e6bdd9784f4289c94"
+dependencies = [
+ "base64",
+ "bitflags 2.6.0",
+ "serde",
+ "serde_derive",
+]
+
+[[package]]
 name = "sapp-jsutils"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -695,6 +716,7 @@ dependencies = [
  "gamepads",
  "macroquad",
  "quad-storage",
+ "ron",
  "serde",
  "toml",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ gamepads = { version = "0.1.6", default-features = false }
 # https://github.com/not-fl3/miniquad/issues/470
 macroquad = { version = "0.4", features=["audio"] }
 quad-storage = "0.1.3"
+ron = "0.8.1"
 serde = { version = "1.0.207", features=["serde_derive"] }
 toml = "0.8.19"
 

--- a/assets/packs/pack-a.toml
+++ b/assets/packs/pack-a.toml
@@ -1,4 +1,5 @@
 title = "Pack A: Starting Out"
+slug = "pack-a"
 description = "Simple levels to learn the rules of Sokoban."
 author = "Brett Chalupa"
 license = "CC0 (Public Domain)"

--- a/assets/packs/yoshio-murase-automatic.toml
+++ b/assets/packs/yoshio-murase-automatic.toml
@@ -1,4 +1,5 @@
 title = "YM Auto"
+slug = "ym-auto"
 description = "These sokoban screens were made automatically by computer. Yosio Murase wrote the program that created these levels and then made the levels available on his sokoban web pages."
 source = "http://sneezingtiger.com/sokoban/levels/yoshioText.html"
 author = "Yoshio Murase"

--- a/src/context.rs
+++ b/src/context.rs
@@ -2,6 +2,7 @@ use crate::assets_path::determine_asset_path;
 use crate::audio;
 use crate::consts::*;
 use crate::font;
+use crate::save::Save;
 use crate::scene::EScene;
 use crate::settings::Settings;
 use crate::texture;
@@ -32,6 +33,7 @@ pub struct Context {
     /// what level is currently being played, if any. needed for reloading from disk
     pub current_level_index: Option<usize>,
     pub settings: Settings,
+    pub save: Save,
 }
 
 impl Context {
@@ -61,6 +63,7 @@ impl Context {
             current_pack_file: None,
             current_level_index: None,
             settings: Settings::load(),
+            save: Save::load(),
         }
     }
 

--- a/src/level/pack.rs
+++ b/src/level/pack.rs
@@ -27,6 +27,8 @@ impl fmt::Display for Difficulty {
 pub struct Pack {
     /// name of the pack
     pub title: String,
+    /// id used for save data; NOTE: changing this will break saves, don't change
+    pub slug: String,
     pub description: String,
     /// who compiled the levels in the pack, often just the designer
     pub author: String,

--- a/src/level/playable_level.rs
+++ b/src/level/playable_level.rs
@@ -49,11 +49,12 @@ pub struct PlayableLevel {
     move_held_delay: f32,
     rewind_held_delay: f32,
     moves: Vec<PlayerMove>,
+    pack_slug: String,
 }
 
 impl PlayableLevel {
     /// creates a new playable level with properly reset data from the specified pack_level
-    pub fn new(pack_level: &PackLevel) -> Self {
+    pub fn new(pack_slug: String, pack_level: &PackLevel) -> Self {
         let level = Level::parse(pack_level).unwrap();
         let player = Entity { pos: level.player };
         let mut crates: Vec<Crate> = vec![];
@@ -80,6 +81,7 @@ impl PlayableLevel {
             move_held_delay: 0.,
             rewind_held_delay: 0.,
             moves: vec![],
+            pack_slug,
         }
     }
 
@@ -268,6 +270,12 @@ impl PlayableLevel {
             }) {
                 play_sfx(ctx, &ctx.audio.sfx.level_complete);
                 self.complete = true;
+                ctx.save.complete_level(
+                    self.pack_slug.clone(),
+                    self.level.title.clone(),
+                    self.steps,
+                    self.pushes,
+                );
             }
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,6 +7,7 @@ pub mod entity;
 pub mod font;
 pub mod input;
 pub mod level;
+pub mod save;
 pub mod scene;
 pub mod settings;
 pub mod text;

--- a/src/save.rs
+++ b/src/save.rs
@@ -1,0 +1,134 @@
+#[cfg(not(target_family = "wasm"))]
+use directories::ProjectDirs;
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+#[cfg(not(target_family = "wasm"))]
+use std::path::PathBuf;
+
+use crate::consts::VERSION;
+
+/// game completion progress
+#[derive(Debug, Deserialize, Serialize)]
+pub struct Save {
+    game_version: String,
+    // string key is PACKSLUG:LEVELNAME
+    level_completions: HashMap<String, LevelCompletion>,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+struct LevelCompletion {
+    pack: String,
+    level: String,
+    steps: i32,
+    pushes: i32,
+}
+
+#[cfg(not(target_family = "wasm"))]
+const SAVE_FILE: &str = "save.ron";
+
+#[cfg(target_family = "wasm")]
+const WASM_SAVE_KEY: &str = "save";
+
+impl Default for Save {
+    fn default() -> Self {
+        Self {
+            game_version: VERSION.to_string(),
+            level_completions: HashMap::new(),
+        }
+    }
+}
+
+impl Save {
+    /// loads the save file from disk; if it doesn't exist, instantiates a new one and saves it
+    pub fn load() -> Self {
+        #[cfg(target_family = "wasm")]
+        let save = Self::load_wasm();
+
+        #[cfg(not(target_family = "wasm"))]
+        let save = Self::load_desktop();
+        save.save();
+
+        save
+    }
+
+    #[cfg(not(target_family = "wasm"))]
+    fn load_desktop() -> Self {
+        let save_path = Self::determine_save_path();
+
+        if save_path.exists() {
+            let toml_str = std::fs::read_to_string(save_path).expect("couldn't read save file");
+            let save: Save = ron::from_str(toml_str.as_str()).unwrap();
+            save
+        } else {
+            Self::default()
+        }
+    }
+
+    #[cfg(not(target_family = "wasm"))]
+    fn determine_save_path() -> PathBuf {
+        // TODO: DRY THIS LINE UP w/ SETTINGS
+        let project_dirs = ProjectDirs::from("com", "brettchalupa", "sokoworld").unwrap();
+        let save_dir = project_dirs.data_local_dir();
+        std::fs::create_dir_all(save_dir).unwrap();
+        let mut save_path = PathBuf::from(save_dir);
+        save_path.push(SAVE_FILE);
+        save_path
+    }
+
+    #[cfg(target_family = "wasm")]
+    fn load_wasm() -> Self {
+        let mut save = Self::default();
+        let storage = &mut quad_storage::STORAGE.lock().unwrap();
+        if let Some(wasm_save) = storage.get(WASM_SAVE_KEY) {
+            save = ron::from_str(wasm_save.as_str()).unwrap();
+        }
+        save
+    }
+
+    pub fn complete_level(
+        &mut self,
+        pack_slug: String,
+        level_title: String,
+        steps: i32,
+        pushes: i32,
+    ) {
+        self.level_completions.insert(
+            Self::level_completion_key(&pack_slug, &level_title),
+            LevelCompletion {
+                pack: pack_slug,
+                level: level_title,
+                steps,
+                pushes,
+            },
+        );
+        self.save();
+    }
+
+    pub fn is_level_complete(&self, pack_slug: &String, level_title: &String) -> bool {
+        self.level_completions
+            .contains_key(&Self::level_completion_key(pack_slug, level_title))
+    }
+
+    fn level_completion_key(pack_slug: &String, level_title: &String) -> String {
+        format!("{}:{}", pack_slug, level_title)
+    }
+
+    /// writes the save to local storage
+    #[cfg(target_family = "wasm")]
+    fn save(&self) {
+        let storage = &mut quad_storage::STORAGE.lock().unwrap();
+        storage.set(WASM_SAVE_KEY, &self.to_ron_string().as_str());
+    }
+
+    #[cfg(not(target_family = "wasm"))]
+    /// writes the save to disk
+    fn save(&self) {
+        std::fs::write(Self::determine_save_path(), self.to_ron_string())
+            .expect("unable to write save file");
+    }
+
+    /// returns the save data in RON format as a pretty string
+    fn to_ron_string(&self) -> String {
+        ron::ser::to_string_pretty(self, ron::ser::PrettyConfig::default()).unwrap()
+    }
+}

--- a/src/scene/gameplay.rs
+++ b/src/scene/gameplay.rs
@@ -35,8 +35,10 @@ impl Scene for Gameplay {
                     ctx.switch_scene_to = Some(EScene::LevelSelect(self.pack.clone()));
                 } else {
                     self.sync_to_ctx(ctx);
-                    self.level =
-                        PlayableLevel::new(self.pack.levels.get(self.level_index).unwrap());
+                    self.level = PlayableLevel::new(
+                        self.pack.slug.clone(),
+                        self.pack.levels.get(self.level_index).unwrap(),
+                    );
                 }
             }
 
@@ -61,7 +63,7 @@ impl Scene for Gameplay {
 impl Gameplay {
     // TODO: determine level_index dynamically based on where level is in the pack
     pub async fn new(ctx: &mut Context, level: PackLevel, level_index: usize, pack: Pack) -> Self {
-        let level = PlayableLevel::new(&level);
+        let level = PlayableLevel::new(pack.slug.clone(), &level);
         let pause_subscene = Pause::new(ctx, pack.clone());
         let mut gameplay = Self {
             level_index,

--- a/src/scene/level_select.rs
+++ b/src/scene/level_select.rs
@@ -78,14 +78,26 @@ impl Scene for LevelSelect {
                 (i as i32 - self.focused_level_index) as f32 * 180. + VIRTUAL_WIDTH / 2. - 60.;
             let title_y = VIRTUAL_HEIGHT / 2. - 58.;
 
+            let title = level.title.clone();
             draw_text(
                 ctx,
-                level.title.as_str(),
+                title.as_str(),
                 title_x,
                 title_y,
                 text::Size::Medium,
                 color,
             );
+
+            if ctx.save.is_level_complete(&self.pack.slug, &title) {
+                draw_text(
+                    ctx,
+                    "complete",
+                    title_x,
+                    title_y + 40.,
+                    text::Size::Small,
+                    color,
+                );
+            }
         }
 
         draw_text(


### PR DESCRIPTION
introduces cross-platform save file using Rusty Object Notation for its
friendliness with Rust (as an experiment).

tracks level completion within a given pack

relies upon pack slug and level title not changing, which I think is
pretty fair/safe to assume when it ships that data won't change

might change during development but that's okay for now as an
expectation of early access

closes https://github.com/brettchalupa/sokoworld/issues/2
